### PR TITLE
XCFramework Support

### DIFF
--- a/CocoaDebugKit/CocoaDebugKit.xcodeproj/project.pbxproj
+++ b/CocoaDebugKit/CocoaDebugKit.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 		CD2761E21B0E1C050000BB5D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 1230;
 				ORGANIZATIONNAME = "Patrick Kladek";
 				TargetAttributes = {
 					CD2761EA1B0E1C050000BB5D = {
@@ -380,6 +380,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -437,6 +438,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -478,7 +480,7 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = "$(SRCROOT)/CocoaDebugKit/Supporting Files/Info.plist";
 				INSTALL_PATH = "@executable_path/../Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kladek.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = CocoaDebugKit;
@@ -506,7 +508,7 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = "$(SRCROOT)/CocoaDebugKit/Supporting Files/Info.plist";
 				INSTALL_PATH = "@executable_path/../Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.kladek.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = CocoaDebugKit;

--- a/CocoaDebugKit/CocoaDebugKit.xcodeproj/project.pbxproj
+++ b/CocoaDebugKit/CocoaDebugKit.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -416,6 +417,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -482,7 +484,6 @@
 				PRODUCT_NAME = CocoaDebugKit;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -511,7 +512,6 @@
 				PRODUCT_NAME = CocoaDebugKit;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SUPPORTS_MACCATALYST = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/CocoaDebugKit/CocoaDebugKit.xcodeproj/xcshareddata/xcschemes/CocoaDebugKit.xcscheme
+++ b/CocoaDebugKit/CocoaDebugKit.xcodeproj/xcshareddata/xcschemes/CocoaDebugKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1230"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CocoaDebugKit/CocoaDebugKit/Supporting Files/Info.plist
+++ b/CocoaDebugKit/CocoaDebugKit/Supporting Files/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1466</string>
+	<string>1471</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2015 Patrick Kladek. All rights reserved.</string>
 	<key>NSPrincipalClass</key>

--- a/CocoaDebugKit/CocoaDebugKit/Supporting Files/Info.plist
+++ b/CocoaDebugKit/CocoaDebugKit/Supporting Files/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1471</string>
+	<string>1472</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2015 Patrick Kladek. All rights reserved.</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
### Description

The the switch to ARM on the Mac changed how Xcode builds frameworks.
Xcode 12.3 fails builds using Carthage so this PR ensures its compatible.